### PR TITLE
Add option to force garbage collection after every image conversion

### DIFF
--- a/ShowPics.Utilities/Settings/FolderSettings.cs
+++ b/ShowPics.Utilities/Settings/FolderSettings.cs
@@ -11,7 +11,8 @@ namespace ShowPics.Utilities.Settings
         public string ThumbnailsPath { get; set; }
         public string ThumbnailsLogicalPrefix { get; set; } = "thumbnails";
         public string OriginalsLogicalPrefix { get; set; } = "files";
-        public int ConvertionThreads { get; set; } = 1;
+        public int ConversionThreads { get; set; } = 1;
+        public bool ForceGCAfterEachImage { get; set; }
     }
 
     public class RootFolderMapping

--- a/ShowPics/CommonServiceConfiguration.cs
+++ b/ShowPics/CommonServiceConfiguration.cs
@@ -33,6 +33,7 @@ namespace ShowPics
 
             services.AddLogging(loggingBuilder =>
             {
+                loggingBuilder.SetMinimumLevel(LogLevel.Trace); // Allow Serilog do the filtering
                 loggingBuilder.AddSerilog(logger, dispose: true);
             });
             // Configuration options

--- a/ShowPics/appsettings.json
+++ b/ShowPics/appsettings.json
@@ -35,6 +35,7 @@
     ],
     //"ThumbnailsPath": "S:\\showpicsthumbnails",
     "ThumbnailsPath": "C:\\workspace\\temp\\ShowPicsThumbnails",
-    "ConvertionThreads": 4
+    "ConversionThreads": 4,
+    "ForceGCAfterEachImage": false
   }
 }


### PR DESCRIPTION
Add option to force garbage collection after every image conversion to keep the process from getting killed on low memory systems